### PR TITLE
updated ULR in pubtator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 inst/doc
+genescraper.Rproj

--- a/R/scrapePubTator.R
+++ b/R/scrapePubTator.R
@@ -1,9 +1,10 @@
 scrapePubTator <- function (IDs) {
 
   # Get the text from the PubTator website for the specified NCBI article id
-  rawOutput <- getURL(str_c('https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/RESTful/tmTool.cgi/BioConcept/',
-                            IDs,
-                            '/PubTator'))
+  # rawOutput <- getURL(str_c('https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/RESTful/tmTool.cgi/BioConcept/',
+  #                           IDs,
+  #                           '/PubTator'))
+  rawOutput <- getURL(str_c('https://www.ncbi.nlm.nih.gov/research/pubtator-api/publications/export/pubtator?pmids=',IDs))
 
   # Create a list of elements from the PubTator website (title, abstract, ...)
   listOutput <- rawOutput %>%


### PR DESCRIPTION
E.g. for pubmed id 1600704 It is changed from
https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/RESTful/tmTool.cgi/BioConcept/1600704/PubTator/
to
https://www.ncbi.nlm.nih.gov/research/pubtator-api/publications/export/pubtator?pmids=1600704